### PR TITLE
#31 Solved - Adding issuer pattern to allow pattern matching on issuers

### DIFF
--- a/src/HexMaster.Functions.JwtBinding/Configuration/JwtBindingConfiguration.cs
+++ b/src/HexMaster.Functions.JwtBinding/Configuration/JwtBindingConfiguration.cs
@@ -6,6 +6,7 @@
         public const string SectionName = Constants.ConfigurationSectionName;
 
         public string Issuer { get; set; }
+        public string IssuerPattern { get; set; }
         public string Audience { get; set; }
         public string Signature { get; set; }
         public string Scopes { get; set; }

--- a/src/HexMaster.Functions.JwtBinding/Exceptions/IssuerPatternValidationException.cs
+++ b/src/HexMaster.Functions.JwtBinding/Exceptions/IssuerPatternValidationException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace HexMaster.Functions.JwtBinding.Exceptions
+{
+    public class IssuerPatternValidationException : Exception
+    {
+        internal IssuerPatternValidationException(string issuer, string pattern)
+            : base($"The issuer '{issuer}' does not match the pattern '{pattern}', token validation failed")
+        {
+        }
+    }
+}

--- a/src/HexMaster.Functions.JwtBinding/HexMaster.Functions.JwtBinding.csproj
+++ b/src/HexMaster.Functions.JwtBinding/HexMaster.Functions.JwtBinding.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Eduard Keilholz</Authors>
     <Product>Azure Functions JWT Validation Input Binding</Product>
     <Description>This is an input binding for Azure Functions allowing you to validate JWT tokens for Azure Functions with a HTTP trigger.</Description>
@@ -12,14 +12,16 @@
 	<IconUrl>https://github.com/nikneem/azure-functions-jwt-binding/raw/main/logo.png</IconUrl>
     <RepositoryUrl>https://github.com/nikneem/azure-functions-jwt-binding</RepositoryUrl>
     <PackageTags>C#, Azure Functions, Binding, JWT, Token, Validation</PackageTags>
-    <PackageReleaseNotes>Added options pattern. This means you no longer have to pass configuration values through the binding attributes. Values from you app config are used instead. You can still use the attribute configuration to configure the binding, or to overwrite the default configuration.
+    <PackageReleaseNotes>Added pattern validation for the issuer. For more information, see issue #31 on GitHub (https://github.com/nikneem/azure-functions-jwt-binding/issues/31)
+
+Added options pattern. This means you no longer have to pass configuration values through the binding attributes. Values from you app config are used instead. You can still use the attribute configuration to configure the binding, or to overwrite the default configuration.
 
 - 1.1.2 - Fixed configuration bug
 - 1.2.0 - Added AllowedIdenities feature</PackageReleaseNotes>
-    <FileVersion>1.2.0.0</FileVersion>
+    <FileVersion>1.3.0.0</FileVersion>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>logo.png</PackageIcon>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#31 Solved

Added IssuerPattern setting that allows you to configure pattern matching for issuer validation and not bind to a specific issuer.

It is still mandatory to configure your own issuer in case you must download signatures, for signature validation.